### PR TITLE
Respect UIDefaults configuraiton with custom LookAndFeel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Added
+* Respect `UIDefauls` table configuration defined in `LookAndFeel` class.(#11)
+* Allow a customizion by inheriting `DockingUISettings` class and overide `getDefaults` method.(#11)
+
 ### Fixed
 * Avoid NPE when drag-n-drop with null hints (#9)
 
@@ -13,6 +17,7 @@ All notable changes to this project will be documented in this file.
 * feat: test UI behavior with Assertj-Swing-JUnit (#7)
 * refactor: annotate deprecations, avoid access to internal class of other class(#6)
 * refactor: avoid redundant casts (#6)
+* refactor: avoid redundant final for static method.(#11)
 
 ## [v3.0.5-2]
 * chore: use nexus-publish plugin to release

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ See https://code.google.com/p/vldocking/ for more information.
   * The background of `AutoHideButtonPanel` is now customizable via the `AutoHideButtonPanel.background` key for `UIManager` (`Color` value)
   * Disable the gradient on `DockViewTitleBar` via the `DockViewTitleBar.disableCustomPaint` key for `UIManager` (`Boolean` value)
   * The border of the main `DockingDesktop` component can be set via the `DockingDesktop.border` key for `UIManager` (`Border` value)
-* Released version 3.0.5 with the above changes
+* Allow customization with key-value in `UIDefaults defaults = UIManager.getDefaults()` table in `LookAndFeel#getDefaults`.
+* Released version 3.1.0 with the above changes
 * More changes in CHANGELOG.md
 
 Changes introduced by cmadsen/vldocking:
@@ -25,26 +26,25 @@ Changes introduced by cmadsen/vldocking:
 * Renamed package names to use old vlsolutions instead of vldocking
 * Fixed issues with read/wrilXML on multiple screens
 * Added new empty ctor to `FloatingDialog` to make floating windows appear in taskbar. Extend `DefaultDockableContainerFactory.createFloatingDockableContainer` and return `new FloatingDialog()`
-* Fixed LAF issues e.g., when switching Substance skin
+* Fixed LAF issues, e.g., when switching Substance skin
 * Fixed issue with borders not being set on single dock windows until an ancestor change events occurred
 
 ## How to get the released versions?
 
 ### Maven Central
 
-Just add this to your `build.gradle` file's `dependencies` block:
+Add this to your `build.gradle` file's `dependencies` block:
 
 ```
-compile 'org.omegat:vldocking:3.0.5-2'
+implementation 'org.omegat:vldocking:3.1.0'
 ```
 
 VLDocking, the swing docking framework
 
-The VLDocking framework is a commercial-grade Swing Framework providing rich docking features which can easily be integrated with existing applications (and of course new ones).
+The VLDocking framework is a commercial-grade Swing Framework providing rich docking features
+which can easily be integrated with existing applications (and of course, new ones).
 
 VLDocking was created in 2004, and is licensed under the LGPL-3.0.
-
-VLDocking is used by companies worldwide and open source projects.
 
 ![](https://vldocking.readthedocs.io/en/latest/vldocking3.jpg)
 

--- a/src/main/java/com/vlsolutions/swing/docking/ui/DockingUISettings.java
+++ b/src/main/java/com/vlsolutions/swing/docking/ui/DockingUISettings.java
@@ -581,6 +581,8 @@ public class DockingUISettings {
     /** Field for installing settings only once */
     protected boolean isSettingsInstalled = false;
 
+    private UIDefaults defaults;
+
     public DockingUISettings() {
     }
 
@@ -612,7 +614,20 @@ public class DockingUISettings {
      */
     public void installUI() {
         if (!isSettingsInstalled) {
-            installUI(getDefaults());
+            defaults = getDefaults(UIManager.getDefaults());
+            installColors();
+            installAutoHideSettings();
+            installBorderSettings();
+            installDockViewSettings();
+            installDockViewTitleBarSettings();
+            installSplitContainerSettings();
+            installCloseableTabs();
+            installTabbedContainerSettings();
+            installIcons();
+            installAccelerators();
+            installDesktopSettings();
+            installFloatingSettings();
+            installToolBarSettings();
             isSettingsInstalled = true;
         }
     }
@@ -634,23 +649,6 @@ public class DockingUISettings {
         return table;
     }
 
-    protected void installUI(UIDefaults table) {
-        installColors(table);
-        installAutoHideSettings(table);
-        installBorderSettings(table);
-        installDockViewSettings(table);
-        installDockViewTitleBarSettings(table);
-        installSplitContainerSettings(table);
-        installCloseableTabs(table);
-        installTabbedContainerSettings(table);
-        installIcons(table);
-        installAccelerators(table);
-        installDesktopSettings(table);
-        installFloatingSettings(table);
-        installToolBarSettings(table);
-        isSettingsInstalled = true;
-    }
-
     /**
      * Allows updating of the ui after a look and feel change.
      * <p>
@@ -662,85 +660,9 @@ public class DockingUISettings {
      * Calling this method after SwingUtilities.updateComponentTreeUI(topLevelComponent) is unspecified (some
      * things will be updated, others not).
      */
-    @Deprecated
     public void updateUI() {
         isSettingsInstalled = false;
         installUI();
-    }
-
-    /** installs the borders */
-    @Deprecated
-    public void installBorderSettings() {
-        installBorderSettings(getDefaults());
-    }
-
-    /** installs the autohide related properties */
-    @Deprecated
-    public void installAutoHideSettings() {
-        installAutoHideSettings(getDefaults());
-    }
-
-    @Deprecated
-    public void installDockViewSettings() {
-        installDockViewSettings(getDefaults());
-    }
-
-    @Deprecated
-    public void installDockViewTitleBarSettings() {
-        installDockViewTitleBarSettings(getDefaults());
-    }
-
-    /** installs the splitpanes related properties */
-    @Deprecated
-    public void installSplitContainerSettings() {
-        installSplitContainerSettings(getDefaults());
-    }
-
-    /** installs the tabbed pane related properties */
-    @Deprecated
-    public void installTabbedContainerSettings() {
-        installTabbedContainerSettings(getDefaults());
-    }
-
-    @Deprecated
-    public void installCloseableTabs() {
-        installCloseableTabs(getDefaults());
-    }
-
-    /** installs icons used by the framework */
-    @Deprecated
-    public void installIcons() {
-        installIcons(getDefaults());
-    }
-
-    /** installs the eyboard shortcuts */
-    @Deprecated
-    public void installAccelerators() {
-        installAccelerators(getDefaults());
-    }
-
-    /** installs the DockinDesktop related properties */
-    @Deprecated
-    public void installDesktopSettings() {
-        installDesktopSettings(getDefaults());
-    }
-
-    /** installs the FloatingDialog related properties */
-    @Deprecated
-    public void installFloatingSettings() {
-        installFloatingSettings(getDefaults());
-    }
-
-    /** installs the toolbar related properties */
-    @Deprecated
-    public void installToolBarSettings() {
-        installToolBarSettings(getDefaults());
-    }
-
-    // ==== Private methods
-
-    private UIDefaults getDefaults() {
-        return getDefaults(UIManager.getDefaults());
     }
 
     private void getBorderSettings(UIDefaults table) {
@@ -766,10 +688,11 @@ public class DockingUISettings {
         }
     }
 
-    private void installBorderSettings(UIDefaults table) {
-        putValue(table, "DockView.singleDockableBorder");
-        putValue(table, "DockView.tabbedDockableBorder");
-        putValue(table, "DockView.maximizedDockableBorder");
+    /** installs the borders */
+    public void installBorderSettings() {
+        putValue(defaults, "DockView.singleDockableBorder");
+        putValue(defaults, "DockView.tabbedDockableBorder");
+        putValue(defaults, "DockView.maximizedDockableBorder");
     }
 
     private void getAutoHideSettings(UIDefaults table) {
@@ -814,20 +737,21 @@ public class DockingUISettings {
         table.putIfAbsent("AutoHideButton.font", table.get("MenuItem.font")); // 2006/01/23
     }
 
-    private void installAutoHideSettings(UIDefaults table) {
-        putValue(table, "AutoHideButtonUI");
-        putValue(table, "AutoHideButtonPanelUI");
-        putValue(table, "AutoHideExpandPanelUI");
-        putValue(table, "AutoHideButton.expandBorderTop");
-        putValue(table, "AutoHideButton.expandBorderBottom");
+    /** installs the autohide related properties */
+    public void installAutoHideSettings() {
+        putValue(defaults, "AutoHideButtonUI");
+        putValue(defaults, "AutoHideButtonPanelUI");
+        putValue(defaults, "AutoHideExpandPanelUI");
+        putValue(defaults, "AutoHideButton.expandBorderTop");
+        putValue(defaults, "AutoHideButton.expandBorderBottom");
 
-        putValue(table, "AutoHideButton.expandBorderLeft");
-        putValue(table, "AutoHideButton.expandBorderRight");
-        putValue(table, "AutoHideButtonPanel.topBorder");
-        putValue(table, "AutoHideButtonPanel.bottomBorder");
-        putValue(table, "AutoHideButtonPanel.leftBorder");
-        putValue(table, "AutoHideButtonPanel.rightBorder");
-        putValue(table, "AutoHideButton.font");
+        putValue(defaults, "AutoHideButton.expandBorderLeft");
+        putValue(defaults, "AutoHideButton.expandBorderRight");
+        putValue(defaults, "AutoHideButtonPanel.topBorder");
+        putValue(defaults, "AutoHideButtonPanel.bottomBorder");
+        putValue(defaults, "AutoHideButtonPanel.leftBorder");
+        putValue(defaults, "AutoHideButtonPanel.rightBorder");
+        putValue(defaults, "AutoHideButton.font");
     }
 
     private void getDockViewSettings(UIDefaults table) {
@@ -836,9 +760,9 @@ public class DockingUISettings {
     }
 
     /** installs the DockView related properties */
-    private void installDockViewSettings(UIDefaults table) {
-        putValue(table, "DockViewUI");
-        putValue(table, "DetachedDockViewUI");
+    public void installDockViewSettings() {
+        putValue(defaults, "DockViewUI");
+        putValue(defaults, "DetachedDockViewUI");
     }
 
     /** installs the DockVieTitleBar related properties */
@@ -879,24 +803,24 @@ public class DockingUISettings {
         }
     }
 
-    private void installDockViewTitleBarSettings(UIDefaults table) {
-        putValue(table, "DockViewTitleBarUI");
-        putValue(table, "DockViewTitleBar.height");
-        putValue(table, "DockViewTitleBar.closeButtonText");
-        putValue(table, "DockViewTitleBar.minimizeButtonText");
-        putValue(table, "DockViewTitleBar.restoreButtonText");
-        putValue(table, "DockViewTitleBar.maximizeButtonText");
-        putValue(table, "DockViewTitleBar.floatButtonText");
-        putValue(table, "DockViewTitleBar.attachButtonText");
-        putValue(table, "DockViewTitleBar.titleFont");
-        putValue(table, "DockViewTitleBar.isCloseButtonDisplayed");
-        putValue(table, "DockViewTitleBar.isHideButtonDisplayed");
-        putValue(table, "DockViewTitleBar.isDockButtonDisplayed");
-        putValue(table, "DockViewTitleBar.isMaximizeButtonDisplayed");
-        putValue(table, "DockViewTitleBar.isRestoreButtonDisplayed");
-        putValue(table, "DockViewTitleBar.isFloatButtonDisplayed");
-        putValue(table, "DockViewTitleBar.isAttachButtonDisplayed");
-        putValue(table, "DockViewTitleBar.border");
+    public void installDockViewTitleBarSettings() {
+        putValue(defaults, "DockViewTitleBarUI");
+        putValue(defaults, "DockViewTitleBar.height");
+        putValue(defaults, "DockViewTitleBar.closeButtonText");
+        putValue(defaults, "DockViewTitleBar.minimizeButtonText");
+        putValue(defaults, "DockViewTitleBar.restoreButtonText");
+        putValue(defaults, "DockViewTitleBar.maximizeButtonText");
+        putValue(defaults, "DockViewTitleBar.floatButtonText");
+        putValue(defaults, "DockViewTitleBar.attachButtonText");
+        putValue(defaults, "DockViewTitleBar.titleFont");
+        putValue(defaults, "DockViewTitleBar.isCloseButtonDisplayed");
+        putValue(defaults, "DockViewTitleBar.isHideButtonDisplayed");
+        putValue(defaults, "DockViewTitleBar.isDockButtonDisplayed");
+        putValue(defaults, "DockViewTitleBar.isMaximizeButtonDisplayed");
+        putValue(defaults, "DockViewTitleBar.isRestoreButtonDisplayed");
+        putValue(defaults, "DockViewTitleBar.isFloatButtonDisplayed");
+        putValue(defaults, "DockViewTitleBar.isAttachButtonDisplayed");
+        putValue(defaults, "DockViewTitleBar.border");
     }
 
     private void getSplitContainerSettings(UIDefaults table) {
@@ -905,10 +829,11 @@ public class DockingUISettings {
         table.putIfAbsent("SplitContainer.isResizingEnabled", Boolean.TRUE); // 2007/08/11
     }
 
-    private void installSplitContainerSettings(UIDefaults table) {
-        putValue(table, "DockingSplitPaneUI");
-        putValue(table, "SplitContainer.dividerSize");
-        putValue(table, "SplitContainer.isResizingEnabled");
+    /** installs the splitpanes related properties */
+    public void installSplitContainerSettings() {
+        putValue(defaults, "DockingSplitPaneUI");
+        putValue(defaults, "SplitContainer.dividerSize");
+        putValue(defaults, "SplitContainer.isResizingEnabled");
     }
 
     private void getTabbedContainerSettings(UIDefaults table) {
@@ -933,16 +858,17 @@ public class DockingUISettings {
         table.putIfAbsent("TabbedContainer.requestFocusOnTabSelection", Boolean.FALSE);
     }
 
-    private void installTabbedContainerSettings(UIDefaults table) {
-        putValue(table, "TabbedDockableContainer.tabPlacement");
-        putValue(table, "DockTabbedPane.closeButtonText");
-        putValue(table, "DockTabbedPane.minimizeButtonText");
-        putValue(table, "DockTabbedPane.restoreButtonText");
-        putValue(table, "DockTabbedPane.maximizeButtonText");
-        putValue(table, "DockTabbedPane.floatButtonText");
-        putValue(table, "DockTabbedPane.attachButtonText");
-        putValue(table, "DockTabbedPane.titleFont");
-        putValue(table, "TabbedContainer.requestFocusOnTabSelection");
+    /** installs the tabbed pane related properties */
+    public void installTabbedContainerSettings() {
+        putValue(defaults, "TabbedDockableContainer.tabPlacement");
+        putValue(defaults, "DockTabbedPane.closeButtonText");
+        putValue(defaults, "DockTabbedPane.minimizeButtonText");
+        putValue(defaults, "DockTabbedPane.restoreButtonText");
+        putValue(defaults, "DockTabbedPane.maximizeButtonText");
+        putValue(defaults, "DockTabbedPane.floatButtonText");
+        putValue(defaults, "DockTabbedPane.attachButtonText");
+        putValue(defaults, "DockTabbedPane.titleFont");
+        putValue(defaults, "TabbedContainer.requestFocusOnTabSelection");
     }
 
     private void getCloseableTabs(UIDefaults table) {
@@ -954,10 +880,10 @@ public class DockingUISettings {
     }
 
     /** installs the closable tabs properties */
-    private void installCloseableTabs(UIDefaults table) {
-        putValue(table, "TabbedPane.otherIconsGap");
-        putValue(table, "TabbedPane.inBetweenOtherIconsGap");
-        putValue(table, "TabbedPane.alternateTabIcons");
+    public void installCloseableTabs() {
+        putValue(defaults, "TabbedPane.otherIconsGap");
+        putValue(defaults, "TabbedPane.inBetweenOtherIconsGap");
+        putValue(defaults, "TabbedPane.alternateTabIcons");
     }
 
     private void getIcons(UIDefaults table) {
@@ -1017,51 +943,52 @@ public class DockingUISettings {
         setIcon(table, "DockTabbedPane.menu.attach", "attach16v2rollover.png");
     }
 
-    private void installIcons(UIDefaults table) {
-        putValue(table, "DockViewTitleBar.close");
-        putValue(table, "DockViewTitleBar.close.rollover");
-        putValue(table, "DockViewTitleBar.close.pressed");
-        putValue(table, "DockViewTitleBar.closeTab");
-        putValue(table, "DockViewTitleBar.closeTab.rollover");
-        putValue(table, "DockViewTitleBar.closeTab.pressed");
-        putValue(table, "DockViewTitleBar.dock");
-        putValue(table, "DockViewTitleBar.dock.rollover");
-        putValue(table, "DockViewTitleBar.dock.pressed");
-        putValue(table, "DockViewTitleBar.hide");
-        putValue(table, "DockViewTitleBar.hide.rollover");
-        putValue(table, "DockViewTitleBar.hide.pressed");
-        putValue(table, "DockViewTitleBar.maximize");
-        putValue(table, "DockViewTitleBar.maximize.pressed");
-        putValue(table, "DockViewTitleBar.maximize.rollover");
-        putValue(table, "DockViewTitleBar.restore");
-        putValue(table, "DockViewTitleBar.restore.pressed");
-        putValue(table, "DockViewTitleBar.restore.rollover");
-        putValue(table, "DockViewTitleBar.float");
-        putValue(table, "DockViewTitleBar.float.rollover");
-        putValue(table, "DockViewTitleBar.float.pressed");
-        putValue(table, "DockViewTitleBar.attach");
-        putValue(table, "DockViewTitleBar.attach.rollover");
-        putValue(table, "DockViewTitleBar.attach.pressed");
-        putValue(table, "DockViewTitleBar.menu.close");
-        putValue(table, "DockViewTitleBar.menu.hide");
-        putValue(table, "DockViewTitleBar.menu.maximize");
-        putValue(table, "DockViewTitleBar.menu.restore");
-        putValue(table, "DockViewTitleBar.menu.dock");
-        putValue(table, "DockViewTitleBar.menu.float");
-        putValue(table, "DockViewTitleBar.menu.attach");
-        putValue(table, "DockTabbedPane.close");
-        putValue(table, "DockTabbedPane.close.rollover");
-        putValue(table, "DockTabbedPane.close.pressed");
-        putValue(table, "DockTabbedPane.unselected_close");
-        putValue(table, "DockTabbedPane.unselected_close.rollover");
-        putValue(table, "DockTabbedPane.unselected_close.pressed");
-        putValue(table, "DockTabbedPane.menu.close");
-        putValue(table, "DockTabbedPane.menu.hide");
-        putValue(table, "DockTabbedPane.menu.maximize");
-        putValue(table, "DockTabbedPane.menu.float");
-        putValue(table, "DockTabbedPane.closeAll");
-        putValue(table, "DockTabbedPane.closeAllOther");
-        putValue(table, "DockTabbedPane.menu.attach");
+    /** installs icons used by the framework */
+    public void installIcons() {
+        putValue(defaults, "DockViewTitleBar.close");
+        putValue(defaults, "DockViewTitleBar.close.rollover");
+        putValue(defaults, "DockViewTitleBar.close.pressed");
+        putValue(defaults, "DockViewTitleBar.closeTab");
+        putValue(defaults, "DockViewTitleBar.closeTab.rollover");
+        putValue(defaults, "DockViewTitleBar.closeTab.pressed");
+        putValue(defaults, "DockViewTitleBar.dock");
+        putValue(defaults, "DockViewTitleBar.dock.rollover");
+        putValue(defaults, "DockViewTitleBar.dock.pressed");
+        putValue(defaults, "DockViewTitleBar.hide");
+        putValue(defaults, "DockViewTitleBar.hide.rollover");
+        putValue(defaults, "DockViewTitleBar.hide.pressed");
+        putValue(defaults, "DockViewTitleBar.maximize");
+        putValue(defaults, "DockViewTitleBar.maximize.pressed");
+        putValue(defaults, "DockViewTitleBar.maximize.rollover");
+        putValue(defaults, "DockViewTitleBar.restore");
+        putValue(defaults, "DockViewTitleBar.restore.pressed");
+        putValue(defaults, "DockViewTitleBar.restore.rollover");
+        putValue(defaults, "DockViewTitleBar.float");
+        putValue(defaults, "DockViewTitleBar.float.rollover");
+        putValue(defaults, "DockViewTitleBar.float.pressed");
+        putValue(defaults, "DockViewTitleBar.attach");
+        putValue(defaults, "DockViewTitleBar.attach.rollover");
+        putValue(defaults, "DockViewTitleBar.attach.pressed");
+        putValue(defaults, "DockViewTitleBar.menu.close");
+        putValue(defaults, "DockViewTitleBar.menu.hide");
+        putValue(defaults, "DockViewTitleBar.menu.maximize");
+        putValue(defaults, "DockViewTitleBar.menu.restore");
+        putValue(defaults, "DockViewTitleBar.menu.dock");
+        putValue(defaults, "DockViewTitleBar.menu.float");
+        putValue(defaults, "DockViewTitleBar.menu.attach");
+        putValue(defaults, "DockTabbedPane.close");
+        putValue(defaults, "DockTabbedPane.close.rollover");
+        putValue(defaults, "DockTabbedPane.close.pressed");
+        putValue(defaults, "DockTabbedPane.unselected_close");
+        putValue(defaults, "DockTabbedPane.unselected_close.rollover");
+        putValue(defaults, "DockTabbedPane.unselected_close.pressed");
+        putValue(defaults, "DockTabbedPane.menu.close");
+        putValue(defaults, "DockTabbedPane.menu.hide");
+        putValue(defaults, "DockTabbedPane.menu.maximize");
+        putValue(defaults, "DockTabbedPane.menu.float");
+        putValue(defaults, "DockTabbedPane.closeAll");
+        putValue(defaults, "DockTabbedPane.closeAllOther");
+        putValue(defaults, "DockTabbedPane.menu.attach");
     }
 
     private void getAccelerators(UIDefaults table) {
@@ -1075,11 +1002,12 @@ public class DockingUISettings {
         setAccelerators(table, "DockingDesktop.floatActionAccelerator", KeyEvent.VK_F5, mask);
     }
 
-    private void installAccelerators(UIDefaults table) {
-        putValue(table, "DockingDesktop.closeActionAccelerator");
-        putValue(table, "DockingDesktop.maximizeActionAccelerator");
-        putValue(table, "DockingDesktop.dockActionAccelerator");
-        putValue(table, "DockingDesktop.floatActionAccelerator");
+    /** installs the eyboard shortcuts */
+    public void installAccelerators() {
+        putValue(defaults, "DockingDesktop.closeActionAccelerator");
+        putValue(defaults, "DockingDesktop.maximizeActionAccelerator");
+        putValue(defaults, "DockingDesktop.dockActionAccelerator");
+        putValue(defaults, "DockingDesktop.floatActionAccelerator");
     }
 
     private void getDesktopSettings(UIDefaults table) {
@@ -1093,15 +1021,16 @@ public class DockingUISettings {
         table.putIfAbsent("DragControler.paintBackgroundUnderDragRect", Boolean.FALSE);
     }
 
-    private void installDesktopSettings(UIDefaults table) {
-        putValue(table, "DockingDesktop.notificationColor");
-        putValue(table, "DockingDesktop.notificationBlinkCount");
-        putValue(table, "DragControler.stopDragCursor");
-        putValue(table, "DragControler.detachCursor");
-        putValue(table, "DragControler.dragCursor");
-        putValue(table, "DragControler.swapDragCursor");
-        putValue(table, "DragControler.isDragAndDropEnabled");
-        putValue(table, "DragControler.paintBackgroundUnderDragRect");
+    /** installs the DockinDesktop related properties */
+    public void installDesktopSettings() {
+        putValue(defaults, "DockingDesktop.notificationColor");
+        putValue(defaults, "DockingDesktop.notificationBlinkCount");
+        putValue(defaults, "DragControler.stopDragCursor");
+        putValue(defaults, "DragControler.detachCursor");
+        putValue(defaults, "DragControler.dragCursor");
+        putValue(defaults, "DragControler.swapDragCursor");
+        putValue(defaults, "DragControler.isDragAndDropEnabled");
+        putValue(defaults, "DragControler.paintBackgroundUnderDragRect");
     }
 
     private void getFloatingSettings(UIDefaults table) {
@@ -1112,11 +1041,12 @@ public class DockingUISettings {
         table.putIfAbsent("FloatingContainer.paintDragShape", Boolean.TRUE);
     }
 
-    private void installFloatingSettings(UIDefaults table) {
-        putValue(table, "FloatingDialog.dialogBorder");
-        putValue(table, "FloatingDialog.titleBorder");
-        putValue(table, "FloatingContainer.followParentWindow");
-        putValue(table, "FloatingContainer.paintDragShape");
+    /** installs the FloatingDialog related properties */
+    public void installFloatingSettings() {
+        putValue(defaults, "FloatingDialog.dialogBorder");
+        putValue(defaults, "FloatingDialog.titleBorder");
+        putValue(defaults, "FloatingContainer.followParentWindow");
+        putValue(defaults, "FloatingContainer.paintDragShape");
     }
 
     private void getToolBarSettings(UIDefaults table) {
@@ -1128,12 +1058,13 @@ public class DockingUISettings {
         setBorder(table, "ToolBarPanel.rightBorder", ToolBarPanelBorder.RIGHT_PANEL);
     }
 
-    private void installToolBarSettings(UIDefaults table) {
-        putValue(table, "ToolBarGripperUI");
-        putValue(table, "ToolBarPanel.topBorder");
-        putValue(table, "ToolBarPanel.leftBorder");
-        putValue(table, "ToolBarPanel.bottomBorder");
-        putValue(table, "ToolBarPanel.rightBorder");
+    /** installs the toolbar related properties */
+    public void installToolBarSettings() {
+        putValue(defaults, "ToolBarGripperUI");
+        putValue(defaults, "ToolBarPanel.topBorder");
+        putValue(defaults, "ToolBarPanel.leftBorder");
+        putValue(defaults, "ToolBarPanel.bottomBorder");
+        putValue(defaults, "ToolBarPanel.rightBorder");
     }
 
     private void getColors(UIDefaults table) {
@@ -1153,9 +1084,9 @@ public class DockingUISettings {
         }
     }
 
-    private void installColors(UIDefaults table) {
-        putValue(table, "VLDocking.shadow");
-        putValue(table, "VLDocking.highlight");
+    private void installColors() {
+        putValue(defaults, "VLDocking.shadow");
+        putValue(defaults, "VLDocking.highlight");
     }
 
     private void putValue(UIDefaults table, String key) {

--- a/src/main/java/com/vlsolutions/swing/docking/ui/DockingUISettings.java
+++ b/src/main/java/com/vlsolutions/swing/docking/ui/DockingUISettings.java
@@ -19,14 +19,17 @@ You can read the complete license here :
 package com.vlsolutions.swing.docking.ui;
 
 import com.vlsolutions.swing.toolbars.ToolBarPanelBorder;
+
 import java.awt.Color;
+import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
+import java.util.Objects;
 import javax.swing.BorderFactory;
-import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.KeyStroke;
 import javax.swing.SwingConstants;
+import javax.swing.UIDefaults;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
 
@@ -35,10 +38,10 @@ import javax.swing.border.Border;
  * <p>
  * There are two ways of modifying the look and feel of the docking framework :
  * <ul>
- * <li>provide a subclass of DockingUISettings and override the installXXX methods
- * <li>directly put UI properties (UIManager.put(key,value)) awaited by the desktop UI delegates. Those are
- * described below.
+ * <li>provide a subclass of DockingUISettings and override the getDefaults(UIDefaults table) method.
+ * <li>directly put UI properties (UIManager.put(key,value)) awaited by the desktop UI delegates.
  * </ul>
+ * The UI properteis are described below.
  * <table border="1">
  * <tr>
  * <th>UI property</th>
@@ -578,12 +581,6 @@ public class DockingUISettings {
     /** Field for installing settings only once */
     protected boolean isSettingsInstalled = false;
 
-    private Color shadow = UIManager.getColor("controlShadow");
-    private Color highlight = UIManager.getColor("controlLtHighlight");
-
-    @SuppressWarnings("unused")
-    private Color darkShadow = UIManager.getColor("controlDkShadow");
-
     public DockingUISettings() {
     }
 
@@ -615,21 +612,43 @@ public class DockingUISettings {
      */
     public void installUI() {
         if (!isSettingsInstalled) {
-            installColors();
-            installAutoHideSettings();
-            installBorderSettings();
-            installDockViewSettings();
-            installDockViewTitleBarSettings();
-            installSplitContainerSettings();
-            installCloseableTabs();
-            installTabbedContainerSettings();
-            installIcons();
-            installAccelerators();
-            installDesktopSettings();
-            installFloatingSettings();
-            installToolBarSettings();
+            installUI(getDefaults());
             isSettingsInstalled = true;
         }
+    }
+
+    protected UIDefaults getDefaults(UIDefaults table) {
+        getColors(table); // should call getColors first.
+        getAutoHideSettings(table);
+        getBorderSettings(table);
+        getDockViewSettings(table);
+        getDockViewTitleBarSettings(table);
+        getSplitContainerSettings(table);
+        getCloseableTabs(table);
+        getTabbedContainerSettings(table);
+        getIcons(table);
+        getAccelerators(table);
+        getDesktopSettings(table);
+        getFloatingSettings(table);
+        getToolBarSettings(table);
+        return table;
+    }
+
+    protected void installUI(UIDefaults table) {
+        installColors(table);
+        installAutoHideSettings(table);
+        installBorderSettings(table);
+        installDockViewSettings(table);
+        installDockViewTitleBarSettings(table);
+        installSplitContainerSettings(table);
+        installCloseableTabs(table);
+        installTabbedContainerSettings(table);
+        installIcons(table);
+        installAccelerators(table);
+        installDesktopSettings(table);
+        installFloatingSettings(table);
+        installToolBarSettings(table);
+        isSettingsInstalled = true;
     }
 
     /**
@@ -643,329 +662,536 @@ public class DockingUISettings {
      * Calling this method after SwingUtilities.updateComponentTreeUI(topLevelComponent) is unspecified (some
      * things will be updated, others not).
      */
+    @Deprecated
     public void updateUI() {
         isSettingsInstalled = false;
         installUI();
     }
 
     /** installs the borders */
+    @Deprecated
     public void installBorderSettings() {
-        // this is for the "flat style" (comment this line, or put a FALSE to
-        // revert to "shadow style"
-
-        // flat style is the default (outside : empty 1 pix / inside :
-        // hightlight-top-left + shadow-bottom-right
-
-        Border innerFlatSingleBorder = BorderFactory.createCompoundBorder(
-                BorderFactory.createMatteBorder(1, 1, 0, 0, highlight),
-                BorderFactory.createMatteBorder(0, 0, 1, 1, shadow));
-
-        Border flatSingleBorder = BorderFactory
-                .createCompoundBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1), innerFlatSingleBorder);
-        UIManager.put("DockView.singleDockableBorder", flatSingleBorder);
-        UIManager.put("DockView.tabbedDockableBorder", null);
-        UIManager.put("DockView.maximizedDockableBorder", null);
+        installBorderSettings(getDefaults());
     }
 
     /** installs the autohide related properties */
+    @Deprecated
     public void installAutoHideSettings() {
-        UIManager.put("AutoHideButtonUI", "com.vlsolutions.swing.docking.ui.AutoHideButtonUI");
-        UIManager.put("AutoHideButtonPanelUI", "com.vlsolutions.swing.docking.ui.AutoHideButtonPanelUI");
-        UIManager.put("AutoHideExpandPanelUI", "com.vlsolutions.swing.docking.ui.AutoHideExpandPanelUI");
+        installAutoHideSettings(getDefaults());
+    }
 
-        UIManager.put("AutoHideButton.expandBorderTop", BorderFactory.createCompoundBorder(
+    @Deprecated
+    public void installDockViewSettings() {
+        installDockViewSettings(getDefaults());
+    }
+
+    @Deprecated
+    public void installDockViewTitleBarSettings() {
+        installDockViewTitleBarSettings(getDefaults());
+    }
+
+    /** installs the splitpanes related properties */
+    @Deprecated
+    public void installSplitContainerSettings() {
+        installSplitContainerSettings(getDefaults());
+    }
+
+    /** installs the tabbed pane related properties */
+    @Deprecated
+    public void installTabbedContainerSettings() {
+        installTabbedContainerSettings(getDefaults());
+    }
+
+    @Deprecated
+    public void installCloseableTabs() {
+        installCloseableTabs(getDefaults());
+    }
+
+    /** installs icons used by the framework */
+    @Deprecated
+    public void installIcons() {
+        installIcons(getDefaults());
+    }
+
+    /** installs the eyboard shortcuts */
+    @Deprecated
+    public void installAccelerators() {
+        installAccelerators(getDefaults());
+    }
+
+    /** installs the DockinDesktop related properties */
+    @Deprecated
+    public void installDesktopSettings() {
+        installDesktopSettings(getDefaults());
+    }
+
+    /** installs the FloatingDialog related properties */
+    @Deprecated
+    public void installFloatingSettings() {
+        installFloatingSettings(getDefaults());
+    }
+
+    /** installs the toolbar related properties */
+    @Deprecated
+    public void installToolBarSettings() {
+        installToolBarSettings(getDefaults());
+    }
+
+    // ==== Private methods
+
+    private UIDefaults getDefaults() {
+        return getDefaults(UIManager.getDefaults());
+    }
+
+    private void getBorderSettings(UIDefaults table) {
+        // this is for the "flat style" (comment this line, or put a FALSE to
+        // revert to "shadow style"
+
+        // flat style is the default
+        // (outside: empty 1 pix /
+        // inside: highlight-top-left + shadow-bottom-right
+        if (table.get("DockView.singleDockableBorder") == null) {
+            final Color shadow = table.getColor("VLDocking.shadow");
+            final Color highlight = table.getColor("VLDocking.highlight");
+
+            Border innerFlatSingleBorder = BorderFactory.createCompoundBorder(
+                    BorderFactory.createMatteBorder(1, 1, 0, 0, highlight),
+                    BorderFactory.createMatteBorder(0, 0, 1, 1, shadow));
+            Border flatSingleBorder = BorderFactory
+                    .createCompoundBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1), innerFlatSingleBorder);
+
+            table.put("DockView.singleDockableBorder", flatSingleBorder);
+            table.put("DockView.tabbedDockableBorder", null);
+            table.put("DockView.maximizedDockableBorder", null);
+        }
+    }
+
+    private void installBorderSettings(UIDefaults table) {
+        putValue(table, "DockView.singleDockableBorder");
+        putValue(table, "DockView.tabbedDockableBorder");
+        putValue(table, "DockView.maximizedDockableBorder");
+    }
+
+    private void getAutoHideSettings(UIDefaults table) {
+        table.putIfAbsent("AutoHideButtonUI", "com.vlsolutions.swing.docking.ui.AutoHideButtonUI");
+        table.putIfAbsent("AutoHideButtonPanelUI", "com.vlsolutions.swing.docking.ui.AutoHideButtonPanelUI");
+        table.putIfAbsent("AutoHideExpandPanelUI", "com.vlsolutions.swing.docking.ui.AutoHideExpandPanelUI");
+
+        final Color shadow = table.getColor("VLDocking.shadow");
+        final Color highlight = table.getColor("VLDocking.highlight");
+
+        table.putIfAbsent("AutoHideButton.expandBorderTop", BorderFactory.createCompoundBorder(
                 BorderFactory.createCompoundBorder(BorderFactory.createMatteBorder(1, 1, 0, 1, shadow),
                         BorderFactory.createMatteBorder(1, 1, 0, 1, highlight)),
                 BorderFactory.createEmptyBorder(0, 6, 0, 6)));
-        UIManager.put("AutoHideButton.expandBorderBottom", BorderFactory.createCompoundBorder(
+        table.putIfAbsent("AutoHideButton.expandBorderBottom", BorderFactory.createCompoundBorder(
                 BorderFactory.createCompoundBorder(BorderFactory.createMatteBorder(0, 1, 1, 1, shadow),
                         BorderFactory.createMatteBorder(0, 1, 1, 1, highlight)),
                 BorderFactory.createEmptyBorder(0, 6, 0, 6)));
-        UIManager.put("AutoHideButton.expandBorderLeft", BorderFactory.createCompoundBorder(
+        table.putIfAbsent("AutoHideButton.expandBorderLeft", BorderFactory.createCompoundBorder(
                 BorderFactory.createCompoundBorder(BorderFactory.createMatteBorder(1, 1, 1, 0, shadow),
                         BorderFactory.createMatteBorder(1, 1, 1, 0, highlight)),
                 BorderFactory.createEmptyBorder(6, 0, 6, 0)));
-        UIManager.put("AutoHideButton.expandBorderRight", BorderFactory.createCompoundBorder(
+        table.putIfAbsent("AutoHideButton.expandBorderRight", BorderFactory.createCompoundBorder(
                 BorderFactory.createCompoundBorder(BorderFactory.createMatteBorder(1, 0, 1, 1, shadow),
                         BorderFactory.createMatteBorder(1, 0, 1, 1, highlight)),
                 BorderFactory.createEmptyBorder(6, 0, 6, 0)));
 
-        UIManager.put("AutoHideButtonPanel.topBorder",
+        table.putIfAbsent("AutoHideButtonPanel.topBorder",
                 BorderFactory.createCompoundBorder(BorderFactory.createEmptyBorder(1, 0, 0, 0),
                         BorderFactory.createMatteBorder(0, 0, 1, 0, shadow)));
-        UIManager.put("AutoHideButtonPanel.bottomBorder",
+        table.putIfAbsent("AutoHideButtonPanel.bottomBorder",
                 BorderFactory.createCompoundBorder(BorderFactory.createEmptyBorder(0, 0, 1, 0),
                         BorderFactory.createMatteBorder(1, 0, 0, 0, shadow)));
 
-        UIManager.put("AutoHideButtonPanel.leftBorder",
+        table.putIfAbsent("AutoHideButtonPanel.leftBorder",
                 BorderFactory.createCompoundBorder(BorderFactory.createEmptyBorder(0, 1, 0, 1),
                         BorderFactory.createMatteBorder(0, 0, 0, 1, shadow)));
-        UIManager.put("AutoHideButtonPanel.rightBorder",
+        table.putIfAbsent("AutoHideButtonPanel.rightBorder",
                 BorderFactory.createCompoundBorder(BorderFactory.createEmptyBorder(0, 1, 0, 1),
                         BorderFactory.createMatteBorder(0, 1, 0, 0, shadow)));
 
-        UIManager.put("AutoHideButton.font", UIManager.get("MenuItem.font")); // 2006/01/23
+        table.putIfAbsent("AutoHideButton.font", table.get("MenuItem.font")); // 2006/01/23
+    }
+
+    private void installAutoHideSettings(UIDefaults table) {
+        putValue(table, "AutoHideButtonUI");
+        putValue(table, "AutoHideButtonPanelUI");
+        putValue(table, "AutoHideExpandPanelUI");
+        putValue(table, "AutoHideButton.expandBorderTop");
+        putValue(table, "AutoHideButton.expandBorderBottom");
+
+        putValue(table, "AutoHideButton.expandBorderLeft");
+        putValue(table, "AutoHideButton.expandBorderRight");
+        putValue(table, "AutoHideButtonPanel.topBorder");
+        putValue(table, "AutoHideButtonPanel.bottomBorder");
+        putValue(table, "AutoHideButtonPanel.leftBorder");
+        putValue(table, "AutoHideButtonPanel.rightBorder");
+        putValue(table, "AutoHideButton.font");
+    }
+
+    private void getDockViewSettings(UIDefaults table) {
+        table.putIfAbsent("DockViewUI", "com.vlsolutions.swing.docking.ui.DockViewUI");
+        table.putIfAbsent("DetachedDockViewUI", "com.vlsolutions.swing.docking.ui.DetachedDockViewUI");
     }
 
     /** installs the DockView related properties */
-    public void installDockViewSettings() {
-        UIManager.put("DockViewUI", "com.vlsolutions.swing.docking.ui.DockViewUI");
-        UIManager.put("DetachedDockViewUI", "com.vlsolutions.swing.docking.ui.DetachedDockViewUI");
+    private void installDockViewSettings(UIDefaults table) {
+        putValue(table, "DockViewUI");
+        putValue(table, "DetachedDockViewUI");
     }
 
     /** installs the DockVieTitleBar related properties */
-    public void installDockViewTitleBarSettings() {
-        UIManager.put("DockViewTitleBarUI", "com.vlsolutions.swing.docking.ui.DockViewTitleBarUI");
+    private void getDockViewTitleBarSettings(UIDefaults table) {
+        table.putIfAbsent("DockViewTitleBarUI", "com.vlsolutions.swing.docking.ui.DockViewTitleBarUI");
 
-        UIManager.put("DockViewTitleBar.height", 20);
-        UIManager.put("DockViewTitleBar.closeButtonText",
-                UIManager.getString("InternalFrameTitlePane.closeButtonText"));
-        UIManager.put("DockViewTitleBar.minimizeButtonText",
-                UIManager.getString("InternalFrameTitlePane.minimizeButtonText"));
-        UIManager.put("DockViewTitleBar.restoreButtonText",
-                UIManager.getString("InternalFrameTitlePane.restoreButtonText"));
-        UIManager.put("DockViewTitleBar.maximizeButtonText",
-                UIManager.getString("InternalFrameTitlePane.maximizeButtonText"));
-        UIManager.put("DockViewTitleBar.floatButtonText", "Detach");
-        UIManager.put("DockViewTitleBar.attachButtonText", "Attach");
+        table.putIfAbsent("DockViewTitleBar.height", 20);
+        table.putIfAbsent("DockViewTitleBar.closeButtonText",
+                table.getString("InternalFrameTitlePane.closeButtonText"));
+        table.putIfAbsent("DockViewTitleBar.minimizeButtonText",
+                table.getString("InternalFrameTitlePane.minimizeButtonText"));
+        table.putIfAbsent("DockViewTitleBar.restoreButtonText",
+                table.getString("InternalFrameTitlePane.restoreButtonText"));
+        table.putIfAbsent("DockViewTitleBar.maximizeButtonText",
+                table.getString("InternalFrameTitlePane.maximizeButtonText"));
+        table.putIfAbsent("DockViewTitleBar.floatButtonText", "Detach");
+        table.putIfAbsent("DockViewTitleBar.attachButtonText", "Attach");
 
         // font to be used in the title bar
-        UIManager.put("DockViewTitleBar.titleFont", UIManager.get("InternalFrame.titleFont"));
+        table.putIfAbsent("DockViewTitleBar.titleFont", table.get("InternalFrame.titleFont"));
 
         // are buttons displayed or just accessible from the contextual menu ?
         // setting one of these flags to false hide the button from the title
         // bar
         // setting to true not necessarily shows the button, as it then depends
         // on the DockKey allowed states.
-        UIManager.put("DockViewTitleBar.isCloseButtonDisplayed", Boolean.TRUE);
-        UIManager.put("DockViewTitleBar.isHideButtonDisplayed", Boolean.TRUE);
-        UIManager.put("DockViewTitleBar.isDockButtonDisplayed", Boolean.TRUE);
-        UIManager.put("DockViewTitleBar.isMaximizeButtonDisplayed", Boolean.TRUE);
-        UIManager.put("DockViewTitleBar.isRestoreButtonDisplayed", Boolean.TRUE);
-        UIManager.put("DockViewTitleBar.isFloatButtonDisplayed", Boolean.TRUE);
-        UIManager.put("DockViewTitleBar.isAttachButtonDisplayed", Boolean.TRUE);
+        table.putIfAbsent("DockViewTitleBar.isCloseButtonDisplayed", Boolean.TRUE);
+        table.putIfAbsent("DockViewTitleBar.isHideButtonDisplayed", Boolean.TRUE);
+        table.putIfAbsent("DockViewTitleBar.isDockButtonDisplayed", Boolean.TRUE);
+        table.putIfAbsent("DockViewTitleBar.isMaximizeButtonDisplayed", Boolean.TRUE);
+        table.putIfAbsent("DockViewTitleBar.isRestoreButtonDisplayed", Boolean.TRUE);
+        table.putIfAbsent("DockViewTitleBar.isFloatButtonDisplayed", Boolean.TRUE);
+        table.putIfAbsent("DockViewTitleBar.isAttachButtonDisplayed", Boolean.TRUE);
 
-        UIManager.put("DockViewTitleBar.border", BorderFactory.createMatteBorder(0, 0, 1, 0, shadow));
+        if (table.get("DockViewTitleBar.border") == null) {
+            final Color shadow = table.getColor("controlShadow");
+            table.put("DockViewTitleBar.border", BorderFactory.createMatteBorder(0, 0, 1, 0, shadow));
+        }
     }
 
-    /** installs the splitpanes related properties */
-    public void installSplitContainerSettings() {
-        UIManager.put("DockingSplitPaneUI", "com.vlsolutions.swing.docking.ui.DockingSplitPaneUI");
-        UIManager.put("SplitContainer.dividerSize", 4);
-        UIManager.put("SplitContainer.isResizingEnabled", Boolean.TRUE); // 2007/08/11
+    private void installDockViewTitleBarSettings(UIDefaults table) {
+        putValue(table, "DockViewTitleBarUI");
+        putValue(table, "DockViewTitleBar.height");
+        putValue(table, "DockViewTitleBar.closeButtonText");
+        putValue(table, "DockViewTitleBar.minimizeButtonText");
+        putValue(table, "DockViewTitleBar.restoreButtonText");
+        putValue(table, "DockViewTitleBar.maximizeButtonText");
+        putValue(table, "DockViewTitleBar.floatButtonText");
+        putValue(table, "DockViewTitleBar.attachButtonText");
+        putValue(table, "DockViewTitleBar.titleFont");
+        putValue(table, "DockViewTitleBar.isCloseButtonDisplayed");
+        putValue(table, "DockViewTitleBar.isHideButtonDisplayed");
+        putValue(table, "DockViewTitleBar.isDockButtonDisplayed");
+        putValue(table, "DockViewTitleBar.isMaximizeButtonDisplayed");
+        putValue(table, "DockViewTitleBar.isRestoreButtonDisplayed");
+        putValue(table, "DockViewTitleBar.isFloatButtonDisplayed");
+        putValue(table, "DockViewTitleBar.isAttachButtonDisplayed");
+        putValue(table, "DockViewTitleBar.border");
     }
 
-    /** installs the tabbed pane related properties */
-    public void installTabbedContainerSettings() {
-        @SuppressWarnings("unused")
-        final String prefix = "/com/vldocking/swing/docking/";
-        UIManager.put("TabbedDockableContainer.tabPlacement", SwingConstants.TOP);
+    private void getSplitContainerSettings(UIDefaults table) {
+        table.putIfAbsent("DockingSplitPaneUI", "com.vlsolutions.swing.docking.ui.DockingSplitPaneUI");
+        table.putIfAbsent("SplitContainer.dividerSize", 4);
+        table.putIfAbsent("SplitContainer.isResizingEnabled", Boolean.TRUE); // 2007/08/11
+    }
 
-        UIManager.put("DockTabbedPane.closeButtonText",
-                UIManager.getString("InternalFrameTitlePane.closeButtonText"));
-        UIManager.put("DockTabbedPane.minimizeButtonText",
-                UIManager.getString("InternalFrameTitlePane.minimizeButtonText"));
-        UIManager.put("DockTabbedPane.restoreButtonText",
-                UIManager.getString("InternalFrameTitlePane.restoreButtonText"));
-        UIManager.put("DockTabbedPane.maximizeButtonText",
-                UIManager.getString("InternalFrameTitlePane.maximizeButtonText"));
-        UIManager.put("DockTabbedPane.floatButtonText", "Detach");
-        UIManager.put("DockTabbedPane.attachButtonText", "Attach"); // 2005/10/07
+    private void installSplitContainerSettings(UIDefaults table) {
+        putValue(table, "DockingSplitPaneUI");
+        putValue(table, "SplitContainer.dividerSize");
+        putValue(table, "SplitContainer.isResizingEnabled");
+    }
 
-        UIManager.put("JTabbedPaneSmartIcon.font", UIManager.getFont("TabbedPane.font")); // 2006/01/23
+    private void getTabbedContainerSettings(UIDefaults table) {
+        table.putIfAbsent("TabbedDockableContainer.tabPlacement", SwingConstants.TOP);
+
+        table.putIfAbsent("DockTabbedPane.closeButtonText",
+                table.getString("InternalFrameTitlePane.closeButtonText"));
+        table.putIfAbsent("DockTabbedPane.minimizeButtonText",
+                table.getString("InternalFrameTitlePane.minimizeButtonText"));
+        table.putIfAbsent("DockTabbedPane.restoreButtonText",
+                table.getString("InternalFrameTitlePane.restoreButtonText"));
+        table.putIfAbsent("DockTabbedPane.maximizeButtonText",
+                table.getString("InternalFrameTitlePane.maximizeButtonText"));
+        table.putIfAbsent("DockTabbedPane.floatButtonText", "Detach");
+        table.putIfAbsent("DockTabbedPane.attachButtonText", "Attach"); // 2005/10/07
+
+        table.putIfAbsent("JTabbedPaneSmartIcon.font", table.getFont("TabbedPane.font")); // 2006/01/23
 
         // set to true to set focus directly into a tabbed component when it
         // becomes
         // selected
-        UIManager.put("TabbedContainer.requestFocusOnTabSelection", Boolean.FALSE);
+        table.putIfAbsent("TabbedContainer.requestFocusOnTabSelection", Boolean.FALSE);
+    }
+
+    private void installTabbedContainerSettings(UIDefaults table) {
+        putValue(table, "TabbedDockableContainer.tabPlacement");
+        putValue(table, "DockTabbedPane.closeButtonText");
+        putValue(table, "DockTabbedPane.minimizeButtonText");
+        putValue(table, "DockTabbedPane.restoreButtonText");
+        putValue(table, "DockTabbedPane.maximizeButtonText");
+        putValue(table, "DockTabbedPane.floatButtonText");
+        putValue(table, "DockTabbedPane.attachButtonText");
+        putValue(table, "DockTabbedPane.titleFont");
+        putValue(table, "TabbedContainer.requestFocusOnTabSelection");
+    }
+
+    private void getCloseableTabs(UIDefaults table) {
+        // this one is already provided by the look and feel
+        // UIManager.put("TabbedPane.textIconGap", new Integer(4));
+        table.putIfAbsent("TabbedPane.otherIconsGap", 8);
+        table.putIfAbsent("TabbedPane.inBetweenOtherIconsGap", 4);
+        table.putIfAbsent("TabbedPane.alternateTabIcons", Boolean.FALSE);
     }
 
     /** installs the closable tabs properties */
-    public void installCloseableTabs() {
-        // this one is already provided by the look and feel
-        // UIManager.put("TabbedPane.textIconGap", new Integer(4));
-        UIManager.put("TabbedPane.otherIconsGap", 8);
-        UIManager.put("TabbedPane.inBetweenOtherIconsGap", 4);
-        UIManager.put("TabbedPane.alternateTabIcons", Boolean.FALSE);
+    private void installCloseableTabs(UIDefaults table) {
+        putValue(table, "TabbedPane.otherIconsGap");
+        putValue(table, "TabbedPane.inBetweenOtherIconsGap");
+        putValue(table, "TabbedPane.alternateTabIcons");
     }
 
-    /** installs icons used by the framework */
-    @SuppressWarnings("unused")
-    public void installIcons() {
-        final String prefix = "/com/vlsolutions/swing/docking/";
-        Icon closeIcon = new ImageIcon(getClass().getResource(prefix + "close16v2.png"));
-        Icon closeRolloverIcon = new ImageIcon(getClass().getResource(prefix + "close16v2rollover.png"));
-        Icon closePressedIcon = new ImageIcon(getClass().getResource(prefix + "close16v2pressed.png"));
+    private void getIcons(UIDefaults table) {
+        setIcon(table, "DockViewTitleBar.close", "close16v2.png");
+        setIcon(table, "DockViewTitleBar.close.rollover", "close16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.close.pressed", "close16v2pressed.png");
+        setIcon(table, "DockViewTitleBar.closeTab", "close16tab.png");
+        setIcon(table, "DockViewTitleBar.closeTab.rollover", "close16tabRollover.png");
+        setIcon(table, "DockViewTitleBar.closeTab.pressed", "close16tabPressed.png");
 
-        Icon closeTabIcon = new ImageIcon(getClass().getResource(prefix + "close16tab.png"));
-        Icon closeTabRolloverIcon = new ImageIcon(getClass().getResource(prefix + "close16tabRollover.png"));
-        Icon closeTabPressedIcon = new ImageIcon(getClass().getResource(prefix + "close16tabPressed.png"));
+        setIcon(table, "DockViewTitleBar.dock", "dock16v2.png");
+        setIcon(table, "DockViewTitleBar.dock.rollover", "dock16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.dock.pressed", "dock16v2pressed.png");
 
-        Icon hideIcon = new ImageIcon(getClass().getResource(prefix + "hide16v2.png"));
-        Icon hideRolloverIcon = new ImageIcon(getClass().getResource(prefix + "hide16v2rollover.png"));
-        Icon maximizeIcon = new ImageIcon(getClass().getResource(prefix + "maximize16v2.png"));
-        Icon maximizeRolloverIcon = new ImageIcon(
-                getClass().getResource(prefix + "maximize16v2rollover.png"));
-        Icon restoreIcon = new ImageIcon(getClass().getResource(prefix + "restore16v2.png"));
-        Icon restoreRolloverIcon = new ImageIcon(getClass().getResource(prefix + "restore16v2rollover.png"));
-        Icon dockRolloverIcon = new ImageIcon(getClass().getResource(prefix + "dock16v2rollover.png"));
+        setIcon(table, "DockViewTitleBar.hide", "hide16v2.png");
+        setIcon(table, "DockViewTitleBar.hide.rollover", "hide16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.hide.pressed", "hide16v2pressed.png");
 
-        Icon floatIcon = new ImageIcon(getClass().getResource(prefix + "float16v2.png"));
-        Icon floatRolloverIcon = new ImageIcon(getClass().getResource(prefix + "float16v2rollover.png"));
-        Icon floatPressedIcon = new ImageIcon(getClass().getResource(prefix + "float16v2pressed.png"));
+        setIcon(table, "DockViewTitleBar.maximize", "maximize16v2.png");
+        setIcon(table, "DockViewTitleBar.maximize.pressed", "maximize16v2pressed.png");
+        setIcon(table, "DockViewTitleBar.maximize.rollover", "maximize16v2rollover.png");
 
-        Icon attachIcon = new ImageIcon(getClass().getResource(prefix + "attach16v2.png"));
-        Icon attachRolloverIcon = new ImageIcon(getClass().getResource(prefix + "attach16v2rollover.png"));
-        Icon attachPressedIcon = new ImageIcon(getClass().getResource(prefix + "attach16v2pressed.png"));
+        setIcon(table, "DockViewTitleBar.restore", "restore16v2.png");
+        setIcon(table, "DockViewTitleBar.restore.pressed", "restore16v2pressed.png");
+        setIcon(table, "DockViewTitleBar.restore.rollover", "restore16v2rollover.png");
 
-        UIManager.put("DockViewTitleBar.close", closeIcon);
-        UIManager.put("DockViewTitleBar.close.rollover", closeRolloverIcon);
-        UIManager.put("DockViewTitleBar.close.pressed", closePressedIcon);
-        UIManager.put("DockViewTitleBar.closeTab", closeTabIcon);
-        UIManager.put("DockViewTitleBar.closeTab.rollover", closeTabRolloverIcon);
-        UIManager.put("DockViewTitleBar.closeTab.pressed", closeTabPressedIcon);
+        setIcon(table, "DockViewTitleBar.float", "float16v2.png");
+        setIcon(table, "DockViewTitleBar.float.rollover", "float16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.float.pressed", "float16v2pressed.png");
 
-        UIManager.put("DockViewTitleBar.dock",
-                new ImageIcon(getClass().getResource(prefix + "dock16v2.png")));
-        UIManager.put("DockViewTitleBar.dock.rollover", dockRolloverIcon);
-        UIManager.put("DockViewTitleBar.dock.pressed",
-                new ImageIcon(getClass().getResource(prefix + "dock16v2pressed.png")));
+        setIcon(table, "DockViewTitleBar.attach", "attach16v2.png");
+        setIcon(table, "DockViewTitleBar.attach.rollover", "attach16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.attach.pressed", "attach16v2pressed.png");
 
-        UIManager.put("DockViewTitleBar.hide", hideIcon);
-        UIManager.put("DockViewTitleBar.hide.rollover", hideRolloverIcon);
-        UIManager.put("DockViewTitleBar.hide.pressed",
-                new ImageIcon(getClass().getResource(prefix + "hide16v2pressed.png")));
+        setIcon(table, "DockViewTitleBar.menu.close", "close16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.menu.hide", "hide16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.menu.maximize", "maximize16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.menu.restore", "restore16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.menu.dock", "dock16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.menu.float", "float16v2rollover.png");
+        setIcon(table, "DockViewTitleBar.menu.attach", "attach16v2rollover.png");
 
-        UIManager.put("DockViewTitleBar.maximize", maximizeIcon);
-        UIManager.put("DockViewTitleBar.maximize.pressed",
-                new ImageIcon(getClass().getResource(prefix + "maximize16v2pressed.png")));
-        UIManager.put("DockViewTitleBar.maximize.rollover", maximizeRolloverIcon);
+        setIcon(table, "DockTabbedPane.close", "close16v2.png");
+        setIcon(table, "DockTabbedPane.close.rollover", "close16v2rollover.png");
+        setIcon(table, "DockTabbedPane.close.pressed", "close16v2pressed.png");
 
-        UIManager.put("DockViewTitleBar.restore", restoreIcon);
-        UIManager.put("DockViewTitleBar.restore.pressed",
-                new ImageIcon(getClass().getResource(prefix + "restore16v2pressed.png")));
-        UIManager.put("DockViewTitleBar.restore.rollover", restoreRolloverIcon);
+        // table.putIfAbsent("DockTabbedPane.unselected_close", null); // 2005/11/14
+        setIcon(table, "DockTabbedPane.unselected_close.rollover", "close16v2rollover.png");
+        setIcon(table, "DockTabbedPane.unselected_close.pressed", "close16v2pressed.png");
 
-        UIManager.put("DockViewTitleBar.float", floatIcon);
-        UIManager.put("DockViewTitleBar.float.rollover", floatRolloverIcon);
-        UIManager.put("DockViewTitleBar.float.pressed", floatPressedIcon);
-
-        UIManager.put("DockViewTitleBar.attach", attachIcon);
-        UIManager.put("DockViewTitleBar.attach.rollover", attachRolloverIcon);
-        UIManager.put("DockViewTitleBar.attach.pressed", attachPressedIcon);
-
-        UIManager.put("DockViewTitleBar.menu.close", closeRolloverIcon);
-        UIManager.put("DockViewTitleBar.menu.hide", hideRolloverIcon);
-        UIManager.put("DockViewTitleBar.menu.maximize", maximizeRolloverIcon);
-        UIManager.put("DockViewTitleBar.menu.restore", restoreRolloverIcon);
-        UIManager.put("DockViewTitleBar.menu.dock", dockRolloverIcon);
-        UIManager.put("DockViewTitleBar.menu.float", floatRolloverIcon);
-        UIManager.put("DockViewTitleBar.menu.attach", attachRolloverIcon);
-
-        UIManager.put("DockTabbedPane.close", closeIcon);
-        UIManager.put("DockTabbedPane.close.rollover", closeRolloverIcon);
-        UIManager.put("DockTabbedPane.close.pressed", closePressedIcon);
-
-        UIManager.put("DockTabbedPane.unselected_close", null); // 2005/11/14
-        UIManager.put("DockTabbedPane.unselected_close.rollover", closeRolloverIcon);
-        UIManager.put("DockTabbedPane.unselected_close.pressed", closePressedIcon);
-
-        UIManager.put("DockTabbedPane.menu.close", closeRolloverIcon);
-        UIManager.put("DockTabbedPane.menu.hide", hideRolloverIcon);
-        UIManager.put("DockTabbedPane.menu.maximize", maximizeRolloverIcon);
-        UIManager.put("DockTabbedPane.menu.float", floatRolloverIcon);
-        UIManager.put("DockTabbedPane.closeAll",
-                new ImageIcon(getClass().getResource(prefix + "closeAll16.png")));
-        UIManager.put("DockTabbedPane.closeAllOther",
-                new ImageIcon(getClass().getResource(prefix + "closeAllOther16.png")));
-        UIManager.put("DockTabbedPane.menu.attach", attachRolloverIcon); // 2005/10/07
+        setIcon(table, "DockTabbedPane.menu.close", "close16v2rollover.png");
+        setIcon(table, "DockTabbedPane.menu.hide", "hide16v2rollover.png");
+        setIcon(table, "DockTabbedPane.menu.maximize", "maximize16v2rollover.png");
+        setIcon(table, "DockTabbedPane.menu.float", "float16v2rollover.png");
+        setIcon(table, "DockTabbedPane.closeAll", "closeAll16.png");
+        setIcon(table, "DockTabbedPane.closeAllOther", "closeAllOther16.png");
+        setIcon(table, "DockTabbedPane.menu.attach", "attach16v2rollover.png");
     }
 
-    /** installs the eyboard shortcuts */
-    public void installAccelerators() {
+    private void installIcons(UIDefaults table) {
+        putValue(table, "DockViewTitleBar.close");
+        putValue(table, "DockViewTitleBar.close.rollover");
+        putValue(table, "DockViewTitleBar.close.pressed");
+        putValue(table, "DockViewTitleBar.closeTab");
+        putValue(table, "DockViewTitleBar.closeTab.rollover");
+        putValue(table, "DockViewTitleBar.closeTab.pressed");
+        putValue(table, "DockViewTitleBar.dock");
+        putValue(table, "DockViewTitleBar.dock.rollover");
+        putValue(table, "DockViewTitleBar.dock.pressed");
+        putValue(table, "DockViewTitleBar.hide");
+        putValue(table, "DockViewTitleBar.hide.rollover");
+        putValue(table, "DockViewTitleBar.hide.pressed");
+        putValue(table, "DockViewTitleBar.maximize");
+        putValue(table, "DockViewTitleBar.maximize.pressed");
+        putValue(table, "DockViewTitleBar.maximize.rollover");
+        putValue(table, "DockViewTitleBar.restore");
+        putValue(table, "DockViewTitleBar.restore.pressed");
+        putValue(table, "DockViewTitleBar.restore.rollover");
+        putValue(table, "DockViewTitleBar.float");
+        putValue(table, "DockViewTitleBar.float.rollover");
+        putValue(table, "DockViewTitleBar.float.pressed");
+        putValue(table, "DockViewTitleBar.attach");
+        putValue(table, "DockViewTitleBar.attach.rollover");
+        putValue(table, "DockViewTitleBar.attach.pressed");
+        putValue(table, "DockViewTitleBar.menu.close");
+        putValue(table, "DockViewTitleBar.menu.hide");
+        putValue(table, "DockViewTitleBar.menu.maximize");
+        putValue(table, "DockViewTitleBar.menu.restore");
+        putValue(table, "DockViewTitleBar.menu.dock");
+        putValue(table, "DockViewTitleBar.menu.float");
+        putValue(table, "DockViewTitleBar.menu.attach");
+        putValue(table, "DockTabbedPane.close");
+        putValue(table, "DockTabbedPane.close.rollover");
+        putValue(table, "DockTabbedPane.close.pressed");
+        putValue(table, "DockTabbedPane.unselected_close");
+        putValue(table, "DockTabbedPane.unselected_close.rollover");
+        putValue(table, "DockTabbedPane.unselected_close.pressed");
+        putValue(table, "DockTabbedPane.menu.close");
+        putValue(table, "DockTabbedPane.menu.hide");
+        putValue(table, "DockTabbedPane.menu.maximize");
+        putValue(table, "DockTabbedPane.menu.float");
+        putValue(table, "DockTabbedPane.closeAll");
+        putValue(table, "DockTabbedPane.closeAllOther");
+        putValue(table, "DockTabbedPane.menu.attach");
+    }
 
-        int MENU_SHORTCUT_MASK = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
-        // this returns CTRL_MASK or META_MASK depending on the platform
-        // (win/mac os)
-
-        UIManager.put("DockingDesktop.closeActionAccelerator",
-                KeyStroke.getKeyStroke(KeyEvent.VK_F4, MENU_SHORTCUT_MASK));
+    private void getAccelerators(UIDefaults table) {
+        final int mask = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
+        setAccelerators(table, "DockingDesktop.closeActionAccelerator", KeyEvent.VK_F4, mask);
         // toggle maximize/restore
-        UIManager.put("DockingDesktop.maximizeActionAccelerator",
-                KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, KeyEvent.SHIFT_DOWN_MASK));
-
+        setAccelerators(table, "DockingDesktop.maximizeActionAccelerator", KeyEvent.VK_ESCAPE,
+                KeyEvent.SHIFT_DOWN_MASK);
         // toggle autohide/dock
-        UIManager.put("DockingDesktop.dockActionAccelerator",
-                KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, MENU_SHORTCUT_MASK));
-
-        UIManager.put("DockingDesktop.floatActionAccelerator",
-                KeyStroke.getKeyStroke(KeyEvent.VK_F5, MENU_SHORTCUT_MASK));
+        setAccelerators(table, "DockingDesktop.dockActionAccelerator", KeyEvent.VK_BACK_SPACE, mask);
+        setAccelerators(table, "DockingDesktop.floatActionAccelerator", KeyEvent.VK_F5, mask);
     }
 
-    /** installs the DockinDesktop related properties */
-    public void installDesktopSettings() {
-        UIManager.put("DockingDesktop.notificationColor", Color.ORANGE);
-        UIManager.put("DockingDesktop.notificationBlinkCount", 5);
-        UIManager.put("DragControler.stopDragCursor",
-                new ImageIcon(getClass().getResource("/com/vlsolutions/swing/docking/stopdragcursor.gif"))
-                        .getImage());
-
-        UIManager.put("DragControler.detachCursor",
-                new ImageIcon(getClass().getResource("/com/vlsolutions/swing/docking/detachCursor.png"))
-                        .getImage());
-
-        UIManager.put("DragControler.dragCursor",
-                new ImageIcon(getClass().getResource("/com/vlsolutions/swing/docking/dragcursor.gif"))
-                        .getImage());
-
-        UIManager.put("DragControler.swapDragCursor",
-                new ImageIcon(getClass().getResource("/com/vlsolutions/swing/docking/swapdragcursor.gif"))
-                        .getImage());
-
-        UIManager.put("DragControler.isDragAndDropEnabled", Boolean.TRUE);
-
-        UIManager.put("DragControler.paintBackgroundUnderDragRect", Boolean.FALSE);
+    private void installAccelerators(UIDefaults table) {
+        putValue(table, "DockingDesktop.closeActionAccelerator");
+        putValue(table, "DockingDesktop.maximizeActionAccelerator");
+        putValue(table, "DockingDesktop.dockActionAccelerator");
+        putValue(table, "DockingDesktop.floatActionAccelerator");
     }
 
-    /** installs the FloatingDialog related properties */
-    public void installFloatingSettings() {
-
-        // Border border = BorderFactory.createMatteBorder(1,1,1,1, darkShadow);
-        // Border titleBorder = BorderFactory.createMatteBorder(0,0,1,0,
-        // highlight);
-
-        Border border = null; // BorderFactory.createEmptyBorder(1,1,1,1);
-        Border titleBorder = null; // BorderFactory.createMatteBorder(0,0,1,0,
-        // shadow);
-
-        UIManager.put("FloatingDialog.dialogBorder", border);
-        UIManager.put("FloatingDialog.titleBorder", titleBorder);
-
-        UIManager.put("FloatingContainer.followParentWindow", Boolean.TRUE);
-        UIManager.put("FloatingContainer.paintDragShape", Boolean.TRUE);
+    private void getDesktopSettings(UIDefaults table) {
+        table.putIfAbsent("DockingDesktop.notificationColor", Color.ORANGE);
+        table.putIfAbsent("DockingDesktop.notificationBlinkCount", 5);
+        setImage(table, "DragControler.stopDragCursor", "stopdragcursor.gif");
+        setImage(table, "DragControler.detachCursor", "detachCursor.png");
+        setImage(table, "DragControler.dragCursor", "dragcursor.gif");
+        setImage(table, "DragControler.swapDragCursor", "swapdragcursor.gif");
+        table.putIfAbsent("DragControler.isDragAndDropEnabled", Boolean.TRUE);
+        table.putIfAbsent("DragControler.paintBackgroundUnderDragRect", Boolean.FALSE);
     }
 
-    /** installs the toolbar related properties */
-    public void installToolBarSettings() {
-        UIManager.put("ToolBarGripperUI", "com.vlsolutions.swing.toolbars.ToolBarGripperUI");
+    private void installDesktopSettings(UIDefaults table) {
+        putValue(table, "DockingDesktop.notificationColor");
+        putValue(table, "DockingDesktop.notificationBlinkCount");
+        putValue(table, "DragControler.stopDragCursor");
+        putValue(table, "DragControler.detachCursor");
+        putValue(table, "DragControler.dragCursor");
+        putValue(table, "DragControler.swapDragCursor");
+        putValue(table, "DragControler.isDragAndDropEnabled");
+        putValue(table, "DragControler.paintBackgroundUnderDragRect");
+    }
+
+    private void getFloatingSettings(UIDefaults table) {
+        // Because these values are null in default, don't override
+        // - table.put("FloatingDialog.dialogBorder", null);
+        // - table.put("FloatingDialog.titleBorder", null);
+        table.putIfAbsent("FloatingContainer.followParentWindow", Boolean.TRUE);
+        table.putIfAbsent("FloatingContainer.paintDragShape", Boolean.TRUE);
+    }
+
+    private void installFloatingSettings(UIDefaults table) {
+        putValue(table, "FloatingDialog.dialogBorder");
+        putValue(table, "FloatingDialog.titleBorder");
+        putValue(table, "FloatingContainer.followParentWindow");
+        putValue(table, "FloatingContainer.paintDragShape");
+    }
+
+    private void getToolBarSettings(UIDefaults table) {
+        table.putIfAbsent("ToolBarGripperUI", "com.vlsolutions.swing.toolbars.ToolBarGripperUI");
         // borders to use with toolbarpanels depending on their position
-        UIManager.put("ToolBarPanel.topBorder", new ToolBarPanelBorder(ToolBarPanelBorder.TOP_PANEL));
-        UIManager.put("ToolBarPanel.leftBorder", new ToolBarPanelBorder(ToolBarPanelBorder.LEFT_PANEL));
-        UIManager.put("ToolBarPanel.bottomBorder", new ToolBarPanelBorder(ToolBarPanelBorder.BOTTOM_PANEL));
-        UIManager.put("ToolBarPanel.rightBorder", new ToolBarPanelBorder(ToolBarPanelBorder.RIGHT_PANEL));
+        setBorder(table, "ToolBarPanel.topBorder", ToolBarPanelBorder.TOP_PANEL);
+        setBorder(table, "ToolBarPanel.leftBorder", ToolBarPanelBorder.LEFT_PANEL);
+        setBorder(table, "ToolBarPanel.bottomBorder", ToolBarPanelBorder.BOTTOM_PANEL);
+        setBorder(table, "ToolBarPanel.rightBorder", ToolBarPanelBorder.RIGHT_PANEL);
     }
 
-    private void installColors() {
-        Color shadow = UIManager.getColor("controlShadow");
-        Color highlight = UIManager.getColor("controlLtHighlight");
-        if (shadow == null) {
-            shadow = Color.GRAY;
-        }
-        if (highlight == null) {
-            highlight = shadow.brighter();
-        }
+    private void installToolBarSettings(UIDefaults table) {
+        putValue(table, "ToolBarGripperUI");
+        putValue(table, "ToolBarPanel.topBorder");
+        putValue(table, "ToolBarPanel.leftBorder");
+        putValue(table, "ToolBarPanel.bottomBorder");
+        putValue(table, "ToolBarPanel.rightBorder");
+    }
 
-        UIManager.put("VLDocking.shadow", shadow);
-        UIManager.put("VLDocking.highlight", highlight);
+    private void getColors(UIDefaults table) {
+        if (table.get("VLDocking.shadow") == null) {
+            Color shadow = table.getColor("controlShadow");
+            if (shadow == null) {
+                shadow = Color.GRAY;
+            }
+            table.put("VLDocking.shadow", shadow);
+        }
+        if (table.get("VLDocking.highlight") == null) {
+            Color highlight = table.getColor("controlLtHighlight");
+            if (highlight == null) {
+                highlight = table.getColor("VLDocking.shadow").brighter();
+            }
+            table.put("VLDocking.highlight", highlight);
+        }
+    }
+
+    private void installColors(UIDefaults table) {
+        putValue(table, "VLDocking.shadow");
+        putValue(table, "VLDocking.highlight");
+    }
+
+    private void putValue(UIDefaults table, String key) {
+        UIManager.put(key, table.get(key));
+    }
+
+    private void setBorder(UIDefaults table, String key, int border) {
+        if (table.get(key) == null) {
+            table.put(key, new ToolBarPanelBorder(border));
+        }
+    }
+
+    private void setAccelerators(UIDefaults table, String key, int keyEvent, int mask) {
+        if (table.get(key) == null) {
+            table.put(key, KeyStroke.getKeyStroke(keyEvent, mask));
+        }
+    }
+
+    private void setIcon(UIDefaults table, String key, String resName) {
+        if (table.get(key) == null) {
+            table.put(key, getIconByName(resName));
+        }
+    }
+
+    private void setImage(UIDefaults table, String key, String resName) {
+        if (table.get(key) == null) {
+            table.put(key, getImageByName(resName));
+        }
+    }
+
+    private ImageIcon getIconByName(String resName) {
+        final String prefix = "/com/vlsolutions/swing/docking/";
+        return new ImageIcon(Objects.requireNonNull(getClass().getResource(prefix + resName)));
+    }
+
+    private Image getImageByName(String resName) {
+        return getIconByName(resName).getImage();
     }
 }

--- a/src/test/java/com/vlsolutions/swing/docking/ui/DockingUISettingsTest.java
+++ b/src/test/java/com/vlsolutions/swing/docking/ui/DockingUISettingsTest.java
@@ -1,0 +1,36 @@
+package com.vlsolutions.swing.docking.ui;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class DockingUISettingsTest {
+
+    private static int notificationBlinkCount = 2;
+
+    @Before
+    public void setUp() {
+        DockingUISettings.setInstance(new CustomDockingUISettings());
+    }
+
+    @Test
+    public void testCustomizedParameters() {
+        DockingUISettings.getInstance().installUI();
+        assertEquals(notificationBlinkCount, UIManager.get("DockingDesktop.notificationBlinkCount"));
+        notificationBlinkCount = 3;
+        DockingUISettings.getInstance().updateUI();
+        assertEquals(notificationBlinkCount, UIManager.get("DockingDesktop.notificationBlinkCount"));
+    }
+
+    public static class CustomDockingUISettings extends DockingUISettings {
+
+        @Override
+        protected UIDefaults getDefaults(UIDefaults table) {
+            table.put("DockingDesktop.notificationBlinkCount", notificationBlinkCount);
+            return super.getDefaults(table);
+        }
+    }
+}

--- a/wiki/tutorial8.md
+++ b/wiki/tutorial8.md
@@ -1,4 +1,4 @@
-# Lesson 8 : Customizing the User Interface 
+# Lesson 8: Customizing the User Interface 
 
 
 This is the 8th part of the VLDocking Framework for Java Swing applications.
@@ -12,10 +12,9 @@ This lesson describes how to change the Look And Feel of VLDocking.
 
 
 VLDocking uses UI delegate classes to paint the look and feel of many of its components.
-Theses classes are dynamically loaded at startup, and use many UI properties to give your application the desired appearance. Here is the list of the current UI delegates :
+These classes are dynamically loaded at startup, and use many UI properties to give your application the desired appearance. Here is the list of the current UI delegates :
 
-
-<table border="1"><thead><tr><th> Component </th><th>UI Delegate class</th></tr></thead>
+<table><thead><tr><th> Component </th><th>UI Delegate class</th></tr></thead>
 <tbody>
 <tr><td>DockView</td><td>com.vlsolutions.swing.docking.ui.DockViewUI</td></tr>
 <tr><td>DockViewTitleBar</td><td>com.vlsolutions.swing.docking.ui.DockViewTitleBarUI</td></tr>
@@ -27,13 +26,12 @@ Theses classes are dynamically loaded at startup, and use many UI properties to 
 </tbody></table>
 
 
-
 ### Replacing UI Delegates 
 
 
 Please note that most UI settings are accessible with UI properties, and thus cas be changed 
 without the need of writing a java class. The only case where you should have to write your own
-UI delegate class is when you want a very different rendering (non rectangular for example). 
+UI delegate class is when you want a very different rendering (non-rectangular, for example). 
 
 
 So, if you need a very different rendering for your dockables, then you will have to provide your custom classes.
@@ -41,25 +39,92 @@ So, if you need a very different rendering for your dockables, then you will hav
 
 Here is how to declare them :
 
+#### Legacy way to declare them
 
- * pre-install the default ui settings in you main() method, or any method prior DockingDesktop usage
+ * pre-install the default ui settings in your `main()` method, or any method prior DockingDesktop usage
  * put your new settings as UIManager properties	
 
 Example :
 
-
 ```java
+import javax.swing.*;
+import com.vlsolutions.swing.docking.ui.DockingUISettings;
+
+public class Main {
     public static void main(String[] args) {
         // first, preload the UI to avoid erasing your own customizations
         DockingUISettings.getInstance().installUI();
         // and start customizing...
+        UIManager.put("DockViewTitleBar.titleFont", UIManager.getFont("Label.font"));
+        UIManager.put("DockViewTitleBar.isCloseButtonDisplayed", false);
         UIManager.put("DockViewTitleBarUI", "your.own.ui.UIDelegateClassName");
         // (replaced the DockViewTitleBar UI by another class)
-        ...
     }
+}
 ```
 
+#### Standard LookAndFeel way
 
+  * Define VLDocking properties in your custom `LookAndFeel#getDefaults`
+  * Set CustomLookAndFeel class name using `UIManager.setLookAndFeel`
+
+```java
+import javax.swing.*;
+
+public class CustomLookAndFeel extends MetalLookAndFeel implements LookAndFeel {
+    public CustomLookAndFeel() {
+        super();
+    }
+    
+    @Override
+    public UIDefaults getDefaults() {
+        UIDefaults config = super.getDefaults();
+        config.put("DockViewTitleBar.titleFont", config.getFont("Label.font"));
+        config.put("DockViewTitleBar.isCloseButtonDisplayed", false);
+        config.put("DockViewTitleBarUI", "your.own.ui.UIDelegateClassName");
+        return config;
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        UIManager.setLookAndFeel(new CustomLookAndFeel());
+        DockingUISettings.getInstance().installUI();
+    }
+}
+```
+
+#### Customize with subclass of `DockingUISettings` class
+
+You can provide a subclass of `DockingUISettings` and override the `getDefaults(UIDefaults table)` method.
+The subclass instance should be registered with `DockingUISettings.setInstance` method.
+
+
+```java
+import com.vlsolutions.swing.docking.ui.DockingUISettings;
+
+public class CustomDockingUISettings extends DockingUISettings {
+
+    public CustomDockingUISettings() {
+        super();
+    }
+
+    @Override
+    protected UIDefaults getDefaults(UIDefaults config) {
+        config.put("DockViewTitleBar.titleFont", config.getFont("Label.font"));
+        config.put("DockViewTitleBar.isCloseButtonDisplayed", false);
+        config.put("DockViewTitleBarUI", "your.own.ui.UIDelegateClassName");
+        return super.getDefaults(config);
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        DockingUISettings.setInstance(new CustomDockingUISettings());
+        DockingUISettings.getInstance().installUI();
+    }
+}
+```
 
 ###  Updating the existing UI 
 
@@ -68,11 +133,15 @@ The easiest way to update the UI is by tweaking the UIManager properties.
 For example, if you want a special border for maximized dockable, use : 
 
 ```java
-    // declare your border
-    Border myBorder = ...
-    // put it in the UI property map.
-    UIManager.put("DockView.maximizedDockableBorder", myBorder);
-    // and that's it !
+public class Main {
+    public static void main(String[] args) {
+        // declare your border
+        Border myBorder = new MyBorder();
+        // put it in the UI property map.
+        UIManager.put("DockView.maximizedDockableBorder", myBorder);
+        // and that's it!
+    }
+}
 ```
 
 
@@ -80,23 +149,24 @@ Please note that *to avoid having your own UI settings beeing erased* by the def
 you will have to follow the pattern :
 
 
- * pre-install the default ui settings in you main() method, or any method prior DockingDesktop usage
+ * pre-install the default ui settings in your `main()` method, or any method prior DockingDesktop usage
  * put your new settings as UIManager properties	
 
 
 
 
 ```java
+public class Main {
     public static void main(String[] args) {
         // first, preload the UI to avoid erasing your own customizations
         DockingUISettings.getInstance().installUI();
 
         // declare your border
-        Border myBorder = ...
+        Border myBorder = new MyBorder();
         // and start customizing...
         UIManager.put("DockView.maximizedDockableBorder", myBorder);
-        ...
     }
+}
 ```
 
 Now that you know how to proceed, here is the long list of customizable properties...
@@ -104,8 +174,7 @@ Now that you know how to proceed, here is the long list of customizable properti
 ## Customizable properties  
 ###  Border properties
 
-<table border="1">
-<thead>
+<table><thead>
 <tr><th>UI property</th> <th>type</th> <th>effect</th></tr></thead>
 <tbody>
 <tr><td>DockView.singleDockableBorder</td> <td>Border</td> <td>border used when the DockView is docked alone (not in a tab)</td></tr>
@@ -130,8 +199,7 @@ Now that you know how to proceed, here is the long list of customizable properti
 
 ###  Color properties
 
-<table border="1">
-<thead>
+<table><thead>
 <tr><th>UI property</th> <th>type</th> <th>effect</th></tr></thead>
 <tbody>
 <tr> <td>DockingDesktop.notificationColor</td> <td>Color</td> <td>blinking color for notifications</td></tr>
@@ -139,8 +207,7 @@ Now that you know how to proceed, here is the long list of customizable properti
 
 ###  Icons 
 
-<table border="1">
-<thead>
+<table><thead>
 <tr><th>UI property</th> <th>type</th> <th>effect</th></tr></thead>
 <tbody>
 <tr> <td>DockViewTitleBar.close</td> <td>Icon</td> <td>Icon for the close button</td></tr>
@@ -189,8 +256,7 @@ property must also be set to true</td></tr>
 
 ###  Labels and Fonts 
 
-<table border="1">
-<thead>
+<table><thead>
 <tr><th>UI property</th> <th>type</th> <th>effect</th></tr></thead>
 <tbody>
 <tr> <td>DockViewTitleBar.closeButtonText</td> <td>String</td> <td>Text of the close button</td></tr>
@@ -209,8 +275,7 @@ property must also be set to true</td></tr>
 
 ###  Displaying buttons in title bars 
 
-<table border="1">
-<thead>
+<table><thead>
 <tr><th>UI property</th> <th>type</th> <th>effect</th></tr></thead>
 <tbody>
 <tr> <td>DockViewTitleBar.isCloseButtonDisplayed</td> <td>boolean</td> <td>display or not the close button in the title bar (still accessible from pop-up menu)</td></tr>
@@ -224,8 +289,7 @@ property must also be set to true</td></tr>
 
 ###  KeyStrokes 
 
-<table border="1">
-<thead>
+<table><thead>
 <tr><th>UI property</th> <th>type</th> <th>effect</th></tr></thead>
 <tbody>
 <tr> <td>DockingDesktop.closeActionAccelerator</td> <td>KeyStroke</td> <td>KeyStroke for close action (on selected dockable)</td></tr>
@@ -237,7 +301,7 @@ property must also be set to true</td></tr>
 ###  UI Delegates 
 
 
-<table border="1"><thead><tr><th>UI property</th><th>type</th><th>effect</th></tr></thead><tbody>
+<table><thead><tr><th>UI property</th><th>type</th><th>effect</th></tr></thead><tbody>
 <tr><td>AutoHideButtonUI</td> <td>class name</td> <td>UI delegate for the AutoHideButton</td></tr>
 <tr><td>AutoHideButtonPanelUI</td> <td>class name</td> <td>UI delegate for the AutoHideButtonPanel</td></tr>
 <tr><td>AutoHideExpandPanelUI</td> <td>class name</td> <td>UI delegate for the AutoHideExpandPanel</td></tr>
@@ -254,7 +318,7 @@ property must also be set to true</td></tr>
 Starting from version 2.0.3 it is now possible to change the mouse cursor images used during 
 drag gestures.
 
-<table border="1"><thead><tr><th>UI property</th><th>type</th><th>effect</th></tr></thead><tbody>
+<table><thead><tr><th>UI property</th><th>type</th><th>effect</th></tr></thead><tbody>
 <tr><td>DragControler.stopDragCursor</td> <td>java.awt.Image</td> <td>Image (max 32x32) used when the mouse pointer is above a place where drop is not possible</td></tr>
 <tr><td>DragControler.detachCursor</td> <td>Image</td> <td>Image used to denote a floating action </td></tr>
 <tr><td>DragControler.dragCursor</td> <td>Image</td> <td>Image used (together with a shape) to denote a position where drop is possible</td></tr>
@@ -264,7 +328,7 @@ drag gestures.
 
 ###  Other properties 
 
-<table border="1">
+<table>
 <thead>
 <tr><th>UI property</th> <th>type</th> <th>effect</th></tr></thead>
 <tbody>
@@ -293,8 +357,12 @@ You can choose select between the following provided styles (more to come) with 
 
 
 ```java
-    // version 1.0 style
-    DockingPreferences.setShadowDesktopStyle();
+public class Main {
+    public static void main(String[] args) {
+        // version 1.0 style
+        DockingPreferences.setShadowDesktopStyle();
+    }
+}
 ```
 
  ![](shadowed_style.jpg)
@@ -302,8 +370,12 @@ You can choose select between the following provided styles (more to come) with 
  _The "Shadow Style"_
 
 ```java
-    // or version 1.0 alternative style
-    DockingPreferences.setDottedDesktopStyle();
+public class Main {
+    public static void main(String[] args) {
+        // or version 1.0 alternative style
+        DockingPreferences.setDottedDesktopStyle();
+    }
+}
 ```
 
  ![](dotted_style.jpg)
@@ -311,8 +383,12 @@ You can choose select between the following provided styles (more to come) with 
  _The "Dotted Style"_
 
 ```java
-    // or version 2.0 default style 
-    DockingPreferences.setFlatDesktopStyle();
+public class Main {
+    public static void main(String[] args) {
+        // or version 2.0 default style 
+        DockingPreferences.setFlatDesktopStyle();
+    }
+}
 ```
 
  ![](flat_style.jpg)


### PR DESCRIPTION
The vldocking UI customization deeply depends on `UIManager.put` overrides.
It is better to respect `LookAndFeel`'s `UIDefaults` configuration table when loading the developer defaults of the library.

This proposal is to add functionality to check a predefined value in `UIDefaults defualts = UIManager.getDefaults()` configuration table. It also provides a way to override defaults in inherit a `DockingUISettings` class and update values by override `getDefaults` method. 