### PR TITLE
refactor: DockingDesktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 * feat: test UI behavior with Assertj-Swing-JUnit (#7)
 * refactor: annotate deprecations, avoid access to internal class of other class(#6)
 * refactor: avoid redundant casts (#6)
+* refactor: DockingDesktop class not to initialize in static context(#12)
 
 ## [v3.0.5-2]
 * chore: use nexus-publish plugin to release


### PR DESCRIPTION
## functional chnage
- Remove static initialization of DockingUISettings and do it in the constructor

## Improve robustness
- Check `currentState` nullity when access
- Avoid always running debug logic
- Change stateChange condition to be currentState != null

## initialize
- Move fields initializer to constructor

## Define with lambda
- Define PropertyChangeListener and ActionListener with lambda

## Optimize loop
- Optimize if-else if-else blocks
- Optimize for-loop

## Style
- Remove redundant initializers
- Optimize empty check with isEmpty()
- clean unused local variable
- javadoc: DockingDesktop
- Simplify DockingDesktop#splitComponent method's stateChange local variable definition
- Replace if block of String comparison to switch block in xmlCreateComponent private method